### PR TITLE
Update version to force a new build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tradingview-alerts-processor",
-  "version": "1.0.0",
-  "description": "Minimalist service desgined to execute TradingView webhooks and process them to cryptocurrencies exchanges.",
+  "version": "1.0.1",
+  "description": "Minimalist service designed to execute TradingView webhooks and process them on cryptocurrencies exchanges.",
   "main": "server.js",
   "author": "Thibault YOU",
   "license": "MIT",


### PR DESCRIPTION
It seems that chokdar (a secondary dependency) was updated shortly after the latest build from the branch.
This may have been enough to cause the breakage that a user is reporting